### PR TITLE
Pretend interpreting span tags as simple text

### DIFF
--- a/mammoth/writers/html.py
+++ b/mammoth/writers/html.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals
+
+import re
 from xml.sax.saxutils import escape
 
 from .abc import Writer
@@ -7,9 +9,20 @@ from .abc import Writer
 class HtmlWriter(Writer):
     def __init__(self):
         self._fragments = []
-    
+
     def text(self, text):
-        self._fragments.append(_escape_html(text))
+        text = _escape_html(text)
+        try:
+            # Following block should guarantee that <span> tags with pagenumbers info will be interpreted 'as they are'
+            # Without changing '<' to '&lt' and so on
+            # So in html they will be interpreted as tags and not as simple text
+
+            pagenum = re.search(r"&lt;span data-page=&quot;(.*?)&quot;&gt;", text).group(1)
+            text = re.sub(r"&lt;span data-page=&quot;\d+&quot;&gt;", f'<span data-page="{pagenum}">', text)
+            text = re.sub(r"&lt;/span&gt;", "</span>", text)
+            self._fragments.append(text)
+        except AttributeError:
+            self._fragments.append(text)
     
     def start(self, name, attributes=None):
         attribute_string = _generate_attribute_string(attributes)

--- a/tests/conversion_tests.py
+++ b/tests/conversion_tests.py
@@ -620,6 +620,13 @@ def when_initials_are_blank_then_comment_author_label_is_blank():
     )))
 
 
+@istest
+def span_bloc_with_pagenum_info_interpreting_as_tag():
+    result = convert_document_element_to_html(
+        documents.run(children=[documents.text('<span data-page="1">Some info</span>')]))
+    assert_equal('<span data-page="1">Some info</span>', result.value)
+
+
 def _paragraph_with_text(text):
     return documents.paragraph(children=[_run_with_text(text)])
 


### PR DESCRIPTION
Edit text method in html.py, so now <span> tags with pagenumbers info will be interpreted 'as they are', without changing '<' to '&lt' and so on. So in html they will be interpreted as tags and not as simple text
